### PR TITLE
Cleaning up more compiler errors caused by new flags.

### DIFF
--- a/src/Contexts.hs
+++ b/src/Contexts.hs
@@ -1,4 +1,4 @@
-module Contexts ( Ctx(Ctx), Binding(BVar), extendVars ) where
+module Contexts ( Ctx(Ctx), Binding(BVar), extendVars, extendVar ) where
 
 import Expressions ( ExprName, QType )
 

--- a/src/Evaluator.hs
+++ b/src/Evaluator.hs
@@ -5,7 +5,6 @@ module Evaluator ( evalExpr ) where
 import Expressions (
   Expr(..),
   ExprName,
-  substExpr,
   substExprs,
   CType(..), QType(..) )
 import Util.DebugOr ( DebugOr, requireOrElse )
@@ -35,7 +34,7 @@ evalExpr e = case e of
     return e
   EAbs _ _ ->
     return e
-  EApp e es -> evalApp e es
+  EApp e' es -> evalApp e' es
   EIf c e1 e2 -> do
     res <- evalExpr c
     b   <- asBool res
@@ -75,11 +74,6 @@ evalBinaryBuiltin x t vs = do
 
 evalExprs :: [Expr] -> DebugOr [Expr]
 evalExprs = traverse evalExpr
-
-asLambda :: Expr -> DebugOr ([(ExprName, CType)], Expr)
-asLambda e = case e of
-  EAbs params e' -> return (params, e')
-  _               -> fail "callee is not callable"
 
 asBool :: Expr -> DebugOr Bool
 asBool e = case e of

--- a/src/Expressions.hs
+++ b/src/Expressions.hs
@@ -13,8 +13,6 @@ module Expressions( Expr(..)
                   , areStructurallyEqualQType
                   ) where
 
-import Parser (Ast(..), AstName(AstName))
-
 
 
 --------------------------------------------------------------------------------
@@ -115,12 +113,12 @@ areStructurallyEqualCType t1 t2 = case (t1,t2) of
 -- Note: This does not compute alpha equivalence.
 areStructurallyEqualExpr :: Expr -> Expr -> Bool
 areStructurallyEqualExpr x y = let
-    are_bindings_eq (ExprName x, t) (ExprName x', t') = x == x' && areStructurallyEqualCType t t'
+    are_bindings_eq (ExprName z, t) (ExprName z', t') = z == z' && areStructurallyEqualCType t t'
     are_list_bindings_eq bs bs' = (length bs == length bs') && all (uncurry are_bindings_eq) (zip bs bs')
   in case (x,y) of
     (ELitBool b, ELitBool b') -> b == b'
     (ELitInt n, ELitInt n') -> n == n'
-    (EVar x t, EVar x' t') -> x == x' && areStructurallyEqualQType t t'
+    (EVar z t, EVar z' t') -> z == z' && areStructurallyEqualQType t t'
     (EAbs bs e, EAbs bs' e') ->
       are_list_bindings_eq bs bs' && areStructurallyEqualExpr e e'
     (EApp e es, EApp e' es') ->
@@ -130,3 +128,4 @@ areStructurallyEqualExpr x y = let
       areStructurallyEqualExpr e1 e1' &&
         areStructurallyEqualExpr e2 e2' &&
           areStructurallyEqualExpr e3 e3'
+    _ -> False

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -12,7 +12,7 @@ import Data.Functor.Identity
 
 import Text.Parsec (many, try, parse)
 import Text.Parsec.Char (oneOf, string, digit, char, letter)
-import Text.Parsec.Combinator (many1, sepBy, sepBy1)
+import Text.Parsec.Combinator (many1, sepBy)
 import Text.Parsec.String (Parser)
 import Text.Parsec.Expr ( buildExpressionParser
                         , Operator(Prefix, Infix)
@@ -212,7 +212,7 @@ intLit = read <$> many1 digit
 literal :: Parser Ast
 literal = asLexeme $ int <|> bool
   where
-    int  = ALitInt . read <$> many1 digit
+    int  = ALitInt <$> intLit
     bool = ALitBool <$> boolLit
 
 

--- a/src/Util/DebugOr.hs
+++ b/src/Util/DebugOr.hs
@@ -20,8 +20,7 @@ module Util.DebugOr (
   showUnderlying
 ) where
 
-import Data.Either ( lefts, rights )
-import Data.List ( intercalate )
+import Data.Either ( rights )
 
 
 

--- a/test/ParserSpec.hs
+++ b/test/ParserSpec.hs
@@ -2,7 +2,6 @@ module ParserSpec ( parserSpec ) where
 
 import Test.HUnit ( assertEqual, Test(TestCase, TestList, TestLabel) )
 import Parser ( simpleParse, Ast(..), AstName (..) )
-import Text.Parsec ( parse )
 import Util.DebugOr ( debugRep )
 
 
@@ -118,4 +117,6 @@ parserSpec :: Test
 parserSpec = TestLabel "Parsing tests" $ TestList [
   TestLabel "simple expressions" $            mkSyntaxTests simpleExprTests,
   TestLabel "binary operation syntax tests" $ mkSyntaxTests binOpTests,
+  TestLabel "lambda syntax tests" $           mkSyntaxTests lambdaTests,
+  TestLabel "conditional syntax tests" $      mkSyntaxTests conditionalTests,
   TestLabel "application syntax tests" $      mkSyntaxTests appTests ]

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,11 +1,12 @@
-import Test.HUnit( Test(TestList, TestLabel), runTestTT )
+import Test.HUnit( runTestTT )
 import ParserSpec ( parserSpec )
 import TypingSpec ( typingSpec )
 import EvaluationSpec ( evalSpec )
 
+-- | Run all of the unit tests.
 main :: IO ()
 main = do
-  runTestTT parserSpec
-  runTestTT typingSpec
-  runTestTT evalSpec
+  _ <- runTestTT parserSpec
+  _ <- runTestTT typingSpec
+  _ <- runTestTT evalSpec
   return ()

--- a/test/TypingSpec.hs
+++ b/test/TypingSpec.hs
@@ -14,8 +14,6 @@ import BuiltIns ( builtinsCtx )
 import Contexts ( Ctx(..), Binding(..) )
 import Util.DebugOr ( DebugOr(..) )
 
-import Text.Parsec ( parse )
-
 
 
 ------ Helper functions --------------------------------------------------------
@@ -48,9 +46,9 @@ mkPassingTypeCheckTest :: CheckTest -> Test
 mkPassingTypeCheckTest x = TestCase (assertBool name cond)
   where
     name = show ctx ++ " |- " ++ show p ++ ": " ++ show t ++ " => " ++ show e
-    cond = applyRelation areStructurallyEqualExpr res exp
+    cond = applyRelation areStructurallyEqualExpr res expd
     res  = DebugOr $ Right e
-    exp  = fst <$> checkExpr ctx p t
+    expd = fst <$> checkExpr ctx p t
     ctx  = ctGetCtx x
     p    = ctGetCode x
     t    = ctGetType x


### PR DESCRIPTION
Not all of the compiler errors raised by `-Werror` and `-Wall` were fixed. This fixes the rest.